### PR TITLE
Klarna integrations

### DIFF
--- a/inc/class-woorule-checkout.php
+++ b/inc/class-woorule-checkout.php
@@ -41,7 +41,7 @@ class Woorule_Checkout {
 					'type'    => 'checkbox',
 					'default' => 'checked',
 					'class'   => array( 'input-checkbox' ),
-					'label'   => get_option( 'woocommerce_rulemailer_settings' )['woorule_checkout_label'],
+					'label'   => Woorule_Options::get_checkout_label(),
 				),
 				1
 			);
@@ -58,9 +58,11 @@ class Woorule_Checkout {
 	 * @return void
 	 */
 	public function custom_checkout_field_update_order_meta( $order_id ) {
-		// phpcs:ignore WordPress.Security.NonceVerification.Missing
-		if ( ! empty( $_POST['woorule_opt_in'] ) ) {
-			update_post_meta( $order_id, 'woorule_opt_in', 'true' );
-		}
+		update_post_meta(
+			$order_id,
+			'woorule_opt_in',
+			// phpcs:ignore WordPress.Security.NonceVerification.Missing
+			empty( $_POST['woorule_opt_in'] ) ? '' : 'true'
+		);
 	}
 }

--- a/inc/class-woorule-options.php
+++ b/inc/class-woorule-options.php
@@ -5,80 +5,165 @@
  * @package Woorule
  */
 
+// phpcs:disable Squiz.Commenting.FunctionComment.SpacingAfterParamType
+
 /**
  * Class Woorule_Options
+ *
+ * @method static get_api_key()
+ * @method static get_checkout_tags()
+ * @method static get_checkout_label()
+ * @method static get_checkout_show()
+ * @method static get_options()
+ * @method static set_api_key( string $value )
+ * @method static set_checkout_tags( string $value )
+ * @method static set_checkout_label( string $value )
+ * @method static set_checkout_show( string $value )
+ * @method static set_options( array $options )
  *
  * @package Woorule
  */
 class Woorule_Options {
+	const OPTIONS_KEY = 'woocommerce_rulemailer_settings';
+
 	/**
 	 * Plugin options.
 	 *
 	 * @var array
 	 */
-	protected static $options = array();
+	protected $options = array();
 
 	/**
-	 * Get API key.
-	 *
-	 * @return string
-	 */
-	public static function get_api_key() {
-		return self::get_option( 'woorule_api_key' );
-	}
-
-	/**
-	 * Get checkout tags.
-	 *
-	 * @return string
-	 */
-	public static function get_checkout_tags() {
-		return self::get_option( 'woorule_checkout_tags' );
-	}
-
-	/**
-	 * Get checkout label.
-	 *
-	 * @return string
-	 */
-	public static function get_checkout_label() {
-		return self::get_option( 'woorule_checkout_label' );
-	}
-
-	/**
-	 * Get checkout show.
-	 *
-	 * @return string
-	 */
-	public static function get_checkout_show() {
-		return self::get_option( 'woorule_checkout_show' );
-	}
-
-	/**
-	 * Get option.
-	 *
-	 * @param string $option_name Option name.
-	 *
-	 * @return string
-	 */
-	protected static function get_option( $option_name ) {
-		if ( empty( self::$options ) ) {
-			self::$options = get_option( 'woocommerce_rulemailer_settings', array() );
-		}
-
-		return isset( self::$options[ $option_name ] ) ? self::$options[ $option_name ] : '';
-	}
-
-	/**
-	 * Set plugin options.
-	 *
-	 * @param array $options Options.
+	 * Woorule_Options constructor.
 	 *
 	 * @return void
 	 */
-	public static function set_options( $options ) {
-		self::$options = wp_parse_args(
-			$options,
+	protected function __construct() {
+		$this->options = get_option( self::OPTIONS_KEY, array() );
+	}
+
+	/**
+	 * Prevent unserializing.
+	 *
+	 * @return void
+	 */
+	protected function __wakeup() {
+	}
+
+	/**
+	 * Prevent cloning.
+	 *
+	 * @return void
+	 */
+	protected function __clone() {
+	}
+
+	/**
+	 * Get class instance.
+	 *
+	 * @return object Instance.
+	 */
+	protected static function get_instance() {
+		static $instance = null;
+
+		if ( is_null( $instance ) ) {
+			$instance = new static();
+		}
+
+		return $instance;
+	}
+
+	/**
+	 * Get option value magic method.
+	 *
+	 * @param string $name Getter functions name.
+	 * @param array $arguments Functions arguments.
+	 *
+	 * @return mixed
+	 *
+	 * @throws BadMethodCallException Exception if not a getter function.
+	 */
+	public static function __callStatic( $name, $arguments ) {
+		$instance = self::get_instance();
+
+		$instance->filter_options();
+
+		if ( 0 === strpos( $name, 'get_' ) ) {
+			return $instance->get( substr( $name, 4 ) );
+		} elseif ( 0 === strpos( $name, 'set_' ) ) {
+			$instance->set( substr( $name, 4 ), $arguments[0] );
+		} else {
+			throw new BadMethodCallException( $name . ' is not defined in ' . __CLASS__ );
+		}
+
+		return null;
+	}
+
+	/**
+	 * Implement getter functions.
+	 *
+	 * @param string $option_name Option name.
+	 *
+	 * @return mixed
+	 *
+	 * @throws BadMethodCallException Exception.
+	 */
+	protected function get( $option_name ) {
+		if ( 'options' === $option_name ) {
+			return $this->options;
+		} elseif ( isset( $this->options[ 'woorule_' . $option_name ] ) ) {
+			return $this->options[ 'woorule_' . $option_name ];
+		} else {
+			throw new BadMethodCallException( $option_name . ' is not defined in ' . __CLASS__ );
+		}
+	}
+
+	/**
+	 * Implement setter functions.
+	 *
+	 * @param string $option_name Option name.
+	 * @param mixed $value Value.
+	 *
+	 * @return void
+	 *
+	 * @throws BadMethodCallException Exception.
+	 */
+	protected function set( $option_name, $value ) {
+		static $updated = null;
+
+		if ( 'options' === $option_name && is_array( $value ) ) {
+			// Merge new options with existent object's options.
+			$value = wp_parse_args( $value, $this->options );
+			$this->filter_options( $value );
+		} elseif ( isset( $this->options[ 'woorule_' . $option_name ] ) ) {
+			$this->options[ 'woorule_' . $option_name ] = $value;
+		} else {
+			throw new BadMethodCallException( $option_name . ' is not defined in ' . __CLASS__ );
+		}
+
+		if ( is_null( $updated ) ) {
+			$updated = true;
+
+			// Save options to DB on shutdown.
+			add_action(
+				'shutdown',
+				// Anonymous function is used because we do want to have public DB update function.
+				function () {
+					$this->filter_options();
+					update_option( self::OPTIONS_KEY, $this->options, false );
+				}
+			);
+		}
+	}
+
+	/**
+	 * Get options defaults.
+	 *
+	 * @return array
+	 */
+	protected function get_options_defaults() {
+		return (array) apply_filters(
+			'woorule_options_defaults',
 			array(
 				'woorule_api_key'        => '',
 				'woorule_checkout_tags'  => '',
@@ -86,7 +171,19 @@ class Woorule_Options {
 				'woorule_checkout_show'  => '',
 			)
 		);
+	}
 
-		update_option( 'woocommerce_rulemailer_settings', self::$options, false );
+	/**
+	 * Filter options.
+	 *
+	 * @param array $options Options.
+	 *
+	 * @return void
+	 */
+	protected function filter_options( $options = null ) {
+		$this->options = shortcode_atts(
+			self::get_options_defaults(),
+			is_null( $options ) ? $this->options : $options
+		);
 	}
 }

--- a/inc/class-woorule-order-hooks.php
+++ b/inc/class-woorule-order-hooks.php
@@ -95,7 +95,7 @@ class Woorule_Order_Hooks {
 			$tags[] = $custom_tags[ $status_to ];
 		}
 
-		if ( $order->get_meta( 'woorule_opt_in' ) ) {
+		if ( 'true' === $order->get_meta( 'woorule_opt_in' ) ) {
 			$tags[] = 'Newsletter'; // Check for a newsletter (checkout) chekbox.
 		}
 

--- a/inc/class-woorule.php
+++ b/inc/class-woorule.php
@@ -24,6 +24,8 @@ class Woorule {
 		add_action( 'init', array( $this, 'update_options' ) );
 
 		if ( $this->is_woocommerce_activated() ) {
+			$this->load_integrations();
+
 			new Woorule_Checkout();
 			new Woorule_Order_Hooks();
 			new Woorule_Shortcode();
@@ -194,18 +196,48 @@ EOT;
 			check_admin_referer( 'woorule-settings' );
 
 			Woorule_Options::set_options(
-				array_map(
-					'sanitize_text_field',
-					array(
-						// phpcs:disable WordPress.Security.ValidatedSanitizedInput
-						'woorule_api_key'        => isset( $_POST['woorule_api'] ) ? $_POST['woorule_api'] : '',
-						'woorule_checkout_tags'  => isset( $_POST['woorule_checkout_tags'] ) ? $_POST['woorule_checkout_tags'] : '',
-						'woorule_checkout_label' => isset( $_POST['woorule_checkout_label'] ) ? $_POST['woorule_checkout_label'] : '',
-						'woorule_checkout_show'  => isset( $_POST['woorule_checkout_show'] ) ? $_POST['woorule_checkout_show'] : '',
-						// phpcs:enable WordPress.Security.ValidatedSanitizedInput
+				apply_filters(
+					'woorule_update_options',
+					array_map(
+						'sanitize_text_field',
+						array(
+							// phpcs:disable WordPress.Security.ValidatedSanitizedInput
+							'woorule_api_key'        => isset( $_POST['woorule_api'] ) ? $_POST['woorule_api'] : '',
+							'woorule_checkout_tags'  => isset( $_POST['woorule_checkout_tags'] ) ? $_POST['woorule_checkout_tags'] : '',
+							'woorule_checkout_label' => isset( $_POST['woorule_checkout_label'] ) ? $_POST['woorule_checkout_label'] : '',
+							'woorule_checkout_show'  => isset( $_POST['woorule_checkout_show'] ) ? $_POST['woorule_checkout_show'] : '',
+							// phpcs:enable WordPress.Security.ValidatedSanitizedInput
+						)
 					)
 				)
 			);
+		}
+	}
+
+	/**
+	 * 3rd party plugins integrations loader.
+	 *
+	 * @return void
+	 */
+	protected function load_integrations() {
+		/**
+		 * Each integration must be in a separate subdirectory under the "integrations" directory.
+		 * Integration directory name will be the name of a bootstrap file and integration class name.
+		 * For example: WoCommerce integration
+		 * |-integrations
+		 * |    |-woocommerce
+		 * |    |   |-class-woorule-woocommerce.php Class Woorule_Woocommerce
+		 */
+		$dir_list = glob( WOORULE_PATH . 'inc/integrations/*', GLOB_ONLYDIR );
+		foreach ( $dir_list as $dir ) {
+			$dir_name   = basename( $dir );
+			$class_name = 'woorule_' . str_replace( '-', '_', $dir_name );
+			$file_name  = 'class-woorule-' . $dir_name . '.php';
+			$file_path  = $dir . '/' . $file_name;
+			if ( is_readable( $file_path ) ) {
+				require_once $file_path;
+				new $class_name();
+			}
 		}
 	}
 }

--- a/inc/class-woorule.php
+++ b/inc/class-woorule.php
@@ -63,9 +63,7 @@ class Woorule {
 	 * @return bool
 	 */
 	protected function is_api_key_set() {
-		$options = get_option( 'woocommerce_rulemailer_settings', array() );
-
-		return ! empty( $options['woorule_api_key'] );
+		return ! empty( Woorule_Options::get_api_key() );
 	}
 
 	/**

--- a/inc/integrations/klarna-checkout-for-woocommerce/class-woorule-klarna-checkout-for-woocommerce.php
+++ b/inc/integrations/klarna-checkout-for-woocommerce/class-woorule-klarna-checkout-for-woocommerce.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * Class Woorule_Klarna_Checkout_For_Woocommerce
+ *
+ * @package Woorule
+ */
+
+// phpcs:disable Squiz.Commenting.FunctionComment.SpacingAfterParamType
+
+/**
+ * Class Woorule_Klarna_Checkout_For_Woocommerce
+ *
+ * @package Woorule
+ */
+class Woorule_Klarna_Checkout_For_Woocommerce {
+	/**
+	 * Woorule_Klarna_Checkout_For_Woocommerce constructor.
+	 */
+	public function __construct() {
+		if ( ! $this->is_klarna_checkout_activated() ) {
+			return;
+		}
+
+		add_filter(
+			'woorule_options_defaults',
+			array( $this, 'add_options_defaults' )
+		);
+
+		add_action(
+			'woorule_admin_settings_after_checkout',
+			array( $this, 'admin_settings' )
+		);
+
+		add_filter(
+			'woorule_update_options',
+			array( $this, 'update_options' )
+		);
+
+		// Important!!! Should be after 'woorule_options_defaults' filter
+		// because otherwise 'klarna_checkout_show' option will not be defined.
+		if ( Woorule_Options::get_klarna_checkout_show() ) {
+			add_filter(
+				'kco_wc_api_request_args',
+				array( $this, 'custom_checkout_field' )
+			);
+
+			add_action(
+				'kco_wc_process_payment',
+				array( $this, 'custom_checkout_field_update_order_meta' ),
+				10,
+				2
+			);
+		}
+	}
+
+	/**
+	 * Check if Klarna Checkout for WooCommerce is activated.
+	 *
+	 * @return bool
+	 */
+	protected function is_klarna_checkout_activated() {
+		return in_array(
+			'klarna-checkout-for-woocommerce/klarna-checkout-for-woocommerce.php',
+			(array) apply_filters( 'active_plugins', get_option( 'active_plugins' ) ),
+			true
+		);
+	}
+
+	/**
+	 * Add options defaults.
+	 *
+	 * @param array $options_defaults Options defaults.
+	 *
+	 * @return array
+	 */
+	public function add_options_defaults( $options_defaults ) {
+		$options_defaults['woorule_klarna_checkout_show'] = '';
+
+		return $options_defaults;
+	}
+
+	/**
+	 * Render admin settings.
+	 *
+	 * @return void
+	 */
+	public function admin_settings() {
+		load_template(
+			WOORULE_PATH . 'inc/integrations/klarna-checkout-for-woocommerce/partials/admin-settings.php',
+			true,
+			array(
+				'show' => Woorule_Options::get_klarna_checkout_show() ? Woorule_Options::get_klarna_checkout_show() : '',
+			)
+		);
+	}
+
+	/**
+	 * Update options.
+	 *
+	 * @param array $options Options.
+	 *
+	 * @return array
+	 */
+	public function update_options( $options ) {
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing
+		$options['woorule_klarna_checkout_show'] = isset( $_POST['woorule_klarna_checkout_show'] )
+			// phpcs:ignore WordPress.Security
+			? sanitize_text_field( $_POST['woorule_klarna_checkout_show'] )
+			: '';
+
+		return $options;
+	}
+
+	/**
+	 * Custom checkout field.
+	 *
+	 * @param array $request_body Request body.
+	 *
+	 * @return array
+	 */
+	public function custom_checkout_field( $request_body ) {
+		$request_body['options']['additional_checkboxes'][] = array(
+			'text'     => Woorule_Options::get_checkout_label(),
+			'checked'  => true,
+			'required' => false,
+			'id'       => 'woorule_klarna_opt_in',
+		);
+
+		return $request_body;
+	}
+
+	/**
+	 * Update order meta.
+	 *
+	 * @param int $order_id Order ID.
+	 * @param array $klarna_order Klarna order data.
+	 *
+	 * @return void
+	 */
+	public function custom_checkout_field_update_order_meta( $order_id, $klarna_order ) {
+		if (
+			isset( $klarna_order['merchant_requested']['additional_checkboxes'] )
+			&&
+			is_array( $klarna_order['merchant_requested']['additional_checkboxes'] )
+			&&
+			! empty( $klarna_order['merchant_requested']['additional_checkboxes'] )
+		) {
+			$checkboxes = wp_list_pluck(
+				$klarna_order['merchant_requested']['additional_checkboxes'],
+				'checked',
+				'id'
+			);
+
+			if (
+				isset( $checkboxes['woorule_klarna_opt_in'] )
+				&&
+				$checkboxes['woorule_klarna_opt_in']
+			) {
+				update_post_meta( $order_id, 'woorule_opt_in', 'true' );
+			} else {
+				update_post_meta( $order_id, 'woorule_opt_in', '' );
+			}
+		}
+	}
+}

--- a/inc/integrations/klarna-checkout-for-woocommerce/partials/admin-settings.php
+++ b/inc/integrations/klarna-checkout-for-woocommerce/partials/admin-settings.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Admin settings.
+ *
+ * @package Woorule
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/* @var array $args Template arguments. */
+?>
+
+<tr>
+	<th>
+		<label for="woorule_klarna_checkout_show">
+			<?php esc_html_e( 'Show signup form on Klarna checkout', 'woorule' ); ?>
+		</label>
+	</th>
+	<td>
+		<input type="checkbox" name="woorule_klarna_checkout_show"
+		       id="woorule_klarna_checkout_show" <?php checked( $args['show'], 'on' ); ?> />
+		<span class="description">
+			<?php esc_html_e( 'Display a signup form on the Klarna checkout form', 'woorule' ); ?>
+		</span>
+	</td>
+</tr>

--- a/inc/partials/admin-settings.php
+++ b/inc/partials/admin-settings.php
@@ -74,12 +74,7 @@ defined( 'ABSPATH' ) || exit;
 				<input name="woorule_api" id="woorule_api" type="text" class="regular-text code"
 				       value="<?php echo esc_attr( $args['api_key'] ); ?>"/>
 				<span class="description">
-					<?php
-					esc_html_e(
-						'You can find your Rule API key in the <a href="https://app.rule.io/#/settings/developer">developer tab in your Rule account</a>.',
-						'woorule'
-					);
-					?>
+					You can find your Rule API key in the <a href="https://app.rule.io/#/settings/developer">developer tab in your Rule account</a>.
 				</span>
 			</td>
 		</tr>

--- a/inc/partials/admin-settings.php
+++ b/inc/partials/admin-settings.php
@@ -58,6 +58,7 @@ defined( 'ABSPATH' ) || exit;
 				</span>
 			</td>
 		</tr>
+		<?php do_action( 'woorule_admin_settings_after_checkout' ); ?>
 		<tr class="line">
 			<th></th>
 			<td></td>


### PR DESCRIPTION
- Added autoloading of integrations (see function `load_integrations` in the `Woorule` class)
- Added the `woorule_update_options` filter to be able to save options for integration
- Removed artifacts after refactoring (nothing serious)

Options:
* the options class is implemented as a singleton
* the options are saved to the database at the end of the wordpress session
* instead of separate functions, one universal static method is used to set and read options

-Added integration with Klarna: When our plugin detects that Klarna Checkout is active, it adds option to the plugin settings page