### PR TITLE
Typo fix

### DIFF
--- a/inc/partials/admin-settings.php
+++ b/inc/partials/admin-settings.php
@@ -95,7 +95,7 @@ defined( 'ABSPATH' ) || exit;
 						__(
 							'You can find your Rule API key in the <a href="https://app.rule.io/#/settings/developer">developer tab in your Rule account</a>.',
 							'woorule'
-						),
+						)
 					);
 					?>
 				</span>


### PR DESCRIPTION
This PR fixes the typo error:
![‹-Rule-Test-Site-—-WordPress](https://user-images.githubusercontent.com/871275/155354680-b82c7d86-b706-461d-9e45-3fea1085a573.png)
